### PR TITLE
Pin import metadata to less than 5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,8 @@ setup(
     keywords=['redis', 'sorted-set', 'kombu'],
     classifiers=[],
     install_requires=[
-        'kombu'
+        'kombu',
+        'import-metadata<5.0',
     ],
     tests_require=[
         'freezegun',


### PR DESCRIPTION
'EntryPoints' object has no attribute 'get' 

https://stackoverflow.com/questions/73929564/entrypoints-object-has-no-attribute-get-digital-ocean

Because importlib-metadata releases v5.0.0 yesterday which it remove deprecated endpoint. 
You can set importlib-metadata<5.0 in ur setup.py so it does not install latest version.